### PR TITLE
Iancrossfield patch 2

### DIFF
--- a/k2phot/channel_transform.py
+++ b/k2phot/channel_transform.py
@@ -154,6 +154,9 @@ def fits_to_chip_centroid(fitsfile):
     flux_sky_mask += mask[np.newaxis,:,:].astype(bool)
     flux_sky = ma.masked_array(flux_sky, flux_sky_mask)
     fbg = ma.median(flux_sky.reshape(flux.shape[0],-1),axis=1)
+    if not np.isfinite(fbg).any(): # This happened for C11, not sure why
+        fbg2 = [ma.median(frame[np.isfinite(frame)]) for frame in flux_sky.reshape(flux.shape[0], -1)]
+        fbg = ma.masked_array(fbg2, np.isnan(fbg2))
 
     # Subtract off background
     flux = flux - fbg[:,np.newaxis,np.newaxis]

--- a/k2phot/channel_transform.py
+++ b/k2phot/channel_transform.py
@@ -129,7 +129,14 @@ def fits_to_chip_centroid(fitsfile):
     # Define rectangular aperture
     wcs = get_wcs(fitsfile)
     ra,dec = hdu0.header['RA_OBJ'],hdu0.header['DEC_OBJ']
-    x,y = wcs.wcs_world2pix(ra,dec,0)
+    try:
+        x,y = wcs.wcs_world2pix(ra,dec,0)
+    except: # if WCS is bogus, make the simplest reasonable assumption
+        x, y = ncol/2., nrow/2.
+        
+    if x<0 or x>ncol-1: x = ncol/2.
+    if y<0 or y>ncol-1: y = ncol/2.
+
     scentx,scenty = np.round([x,y]).astype(int)
     nrings = (apsize-1)/2
 

--- a/k2phot/imagestack.py
+++ b/k2phot/imagestack.py
@@ -46,7 +46,15 @@ class ImageStack(object):
         
         wcs = get_wcs(self.pixfile)
         ra,dec = self.headers[0]['RA_OBJ'],self.headers[0]['DEC_OBJ']
-        x,y = wcs.wcs_world2pix(ra,dec,0)
+        try:
+            x,y = wcs.wcs_world2pix(ra,dec,0)
+        except: # in case WCS is bad (e.g. kadenza-generated target pixel files)
+            x, y = self.headers[2]['NAXIS1']/2., self.headers[2]['NAXIS2']/2.
+        
+        # If x,y are bogus, make the simplest reasonable assumption:
+        if x>self.headers[2]['NAXIS1']-1 or x<0: x = self.headers[2]['NAXIS1']/2.
+        if y>self.headers[2]['NAXIS2']-1. or y<0: y =self.headers[2]['NAXIS2']/2.
+            
         x = float(x)
         y = float(y)
         return x,y

--- a/k2phot/imagestack.py
+++ b/k2phot/imagestack.py
@@ -55,8 +55,8 @@ class ImageStack(object):
         if x>self.headers[2]['NAXIS1']-1 or x<0: x = self.headers[2]['NAXIS1']/2.
         if y>self.headers[2]['NAXIS2']-1. or y<0: y =self.headers[2]['NAXIS2']/2.
             
-        x = float(x)
-        y = float(y)
+        x = int(x)
+        y = int(y)
         return x,y
 
     def set_fbackground(self):

--- a/k2phot/pipeline_core.py
+++ b/k2phot/pipeline_core.py
@@ -214,7 +214,7 @@ class Pipeline(object):
         dfaper = copy.deepcopy(dfaper0)
 
         dfaper = pd.DataFrame(dfaper)
-        dfaper = dfaper.sort('npix')
+        dfaper = dfaper.sort_values(by='npix')
         dfaper.index = range(len(dfaper))
 
         # Check to see if best aperture is bounded on both sides. If


### PR DESCRIPTION
Works for bad WCS headers (e.g. kadenza-generated target pixel files).

Also fixes a pandas.dataFrame.sort --> sort_values bug.